### PR TITLE
200-ops/day2: Add note for time to instantiate autoscaled ARO workers

### DIFF
--- a/aro-content/200-ops/day2/autoscaling.md
+++ b/aro-content/200-ops/day2/autoscaling.md
@@ -168,6 +168,8 @@ Now let's test the cluster autoscaler and see it in action. To do so, we'll depl
     user1-cluster-8kvh4-worker-{{ azure_region }}3   1         1         1       1           6h47m
     ```
 
+    !!! info "If you see READY and AVAILABLE at 1 still, don't panic! It can take a few minutes for the workers to instantiate. Try checking again after 3-5 minutes."
+
     This shows that the cluster autoscaler is working on scaling the MachineSet up to 3.
 
 1. Now let's watch the cluster autoscaler create and delete machines as necessary. To do so, run the following command:


### PR DESCRIPTION
It takes a few minutes for new worker nodes to be provisioned and attached, so let the reader know that.